### PR TITLE
Placeholder regex matches too much

### DIFF
--- a/plugins/dateplaceholder.php
+++ b/plugins/dateplaceholder.php
@@ -119,7 +119,8 @@ class dateplaceholder extends phplistPlugin {
   }
   
   function parseAll($placeholder,$text) {
-      preg_match_all('/\['.strtoupper($placeholder).':?(.*)\]/',$text,$matches);
+      preg_match_all("/\[$placeholder:?(.*?)\]/i",$text,$matches);
+
       for ($i = 0; $i<sizeof($matches[0]); $i++) {          
           $text = str_replace($matches[0][$i],$this->dateReplacement($placeholder,$matches[1][$i]),$text);
       }


### PR DESCRIPTION
The regex to match a placeholder is greedy, so matches everything up to the final ']' instead of only up to the next ']'.

```
'/\['.strtoupper($placeholder).':?(.*)\]/'
```

This change makes it ungreedy and case-insensitive as people might expect to be able to use today instead of TODAY.
